### PR TITLE
glibc-devel library addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 microfocus cookbook CHANGELOG
 =============================
+4.1.0 (2020-08-06)
+------------------
+- Updates to packages, added glibc-devel in addition to existing glibc-devel.i686.
 
 4.0.0 (2020-08-06)
 ------------------

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Usage
 Include `microfocus` as a dependency in your cookbook's `metadata.rb`.
 
 ```ruby
-depends 'microfocus', '~> 4.0.0'
+depends 'microfocus', '~> 4.1.0'
 ```
 
 Resources

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'serverteam@derby.ac.uk'
 license 'Apache 2.0'
 description 'Provides microfocus_server_express resource'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '4.0.0'
+version '4.1.0'
 source_url 'https://github.com/universityofderby/chef-microfocus'
 issues_url 'https://github.com/universityofderby/chef-microfocus/issues'
 

--- a/resources/visual_cobol.rb
+++ b/resources/visual_cobol.rb
@@ -26,7 +26,6 @@ property :owner, String, default: 'root'
 property :visual_cobol_checksum, String
 property :visual_cobol_install_path, String, default: '/opt/microfocus/VisualCOBOL'
 property :visual_cobol_license_checksum, String
-#property :visual_cobol_license_install_tool, String, default: '/var/microfocuslicensing/bin/cesadmintool.sh'
 property :visual_cobol_license_bin_path, String, default: '/var/microfocuslicensing/bin'
 property :visual_cobol_license_path, String, default: lazy {"#{visual_cobol_install_path}/etc/PS-VC-UNIX-Linux"}
 property :visual_cobol_license_url, String, required: true
@@ -35,7 +34,7 @@ property :visual_cobol_url, String, required: true
 
 # default action :create
 action :create do
-  %w[glibc libgcc libstdc++ glibc-devel.i686 gcc ed pax xterm].each do |p|
+  %w[ed gcc glibc glibc-devel glibc-devel.i686 libgcc libstdc++ pax xterm].each do |p|
     package p
   end
 

--- a/test/integration/visual_cobol/default_spec.rb
+++ b/test/integration/visual_cobol/default_spec.rb
@@ -1,5 +1,5 @@
 # packages
-%w[glibc libgcc libstdc++ glibc-devel.i686 gcc ed pax xterm].each do |p|
+%w[ed gcc glibc glibc-devel glibc-devel.i686 libgcc libstdc++ pax xterm].each do |p|
   describe package(p) do
     it { should be_installed }
   end


### PR DESCRIPTION
glibc-devel library additions - installs x86_64 as well as i686 version.